### PR TITLE
Add pip command for installing melisa

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ We are going to create really cool cache configuration, so don't worry about the
 ---
 ## Install MelisaPy
 
-NOTE: Currently, installation is only possible using GitHub
-
+```commandline
+pip install melisa
+```
+Or, alternatively:
 ```commandline
 pip install git+https://github.com/MelisaDev/melisa
 ```

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ We are going to create really cool cache configuration, so don't worry about the
 ---
 ## Install MelisaPy
 
-Installing from PyPi:
+### Installing from PyPi:
 ```commandline
 pip install melisa
 ```
-Installing from Git:
+### Installing from Git:
 ```commandline
 pip install git+https://github.com/MelisaDev/melisa
 ```

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ We are going to create really cool cache configuration, so don't worry about the
 ---
 ## Install MelisaPy
 
+Installing from PyPi:
 ```commandline
 pip install melisa
 ```
-Or, alternatively:
+Installing from Git:
 ```commandline
 pip install git+https://github.com/MelisaDev/melisa
 ```


### PR DESCRIPTION
You can install `Melisa` without using `git`, so I added this method to README